### PR TITLE
(Book) Restores missing step in objects.asc

### DIFF
--- a/book/10-git-internals/sections/objects.asc
+++ b/book/10-git-internals/sections/objects.asc
@@ -188,6 +188,8 @@ You'll now create a new tree with the second version of `test.txt` and a new fil
 [source,console]
 ----
 $ echo 'new file' > new.txt
+$ git update-index --cacheinfo 100644 \
+  1f7a7a472abf3dd9643fd615f6da379c4acb3e3a test.txt
 $ git update-index test.txt
 $ git update-index --add new.txt
 ----


### PR DESCRIPTION
Restores missing step: update cache to point to "new" test.txt (`1f7a7a472abf3dd9643fd615f6da379c4acb3e3a`) when building the tree `0155eb4229851634a0f03eb265b69f5a2d56f341`
## Explanation

When building the tree whose SHA1 will be `0155eb4`, the text says _"You’ll now create a new tree with the second version of test.txt and a new file as well"_, but it never updates the index to point to the second version of test.txt, which means that when you run `git write-tree` in the next step you don't get `0155eb4229851634a0f03eb265b69f5a2d56f341` as the SHA.

This patch adds a step to the instructions that updates the index to point to that second version of test.txt. When you include this step, you get the right SHA.
